### PR TITLE
fix normalization TPM

### DIFF
--- a/transcriptomics_data_service/routers/normalization.py
+++ b/transcriptomics_data_service/routers/normalization.py
@@ -144,9 +144,11 @@ async def _update_normalized_values(
     )
     raw_count_dict = {(expr.gene_code, expr.sample_id): expr.raw_count for expr in existing_expressions}
 
-    normalized_df = normalized_df.reset_index().melt(
-        id_vars="GeneID", var_name="SampleID", value_name="NormalizedValue").dropna(
-            subset=["NormalizedValue"])
+    normalized_df = (
+        normalized_df.reset_index()
+        .melt(id_vars="GeneID", var_name="SampleID", value_name="NormalizedValue")
+        .dropna(subset=["NormalizedValue"])
+    )
 
     expressions = []
     for _, row in normalized_df.iterrows():

--- a/transcriptomics_data_service/routers/normalization.py
+++ b/transcriptomics_data_service/routers/normalization.py
@@ -145,8 +145,8 @@ async def _update_normalized_values(
     raw_count_dict = {(expr.gene_code, expr.sample_id): expr.raw_count for expr in existing_expressions}
 
     normalized_df = normalized_df.reset_index().melt(
-        id_vars="GeneID", var_name="SampleID", value_name="NormalizedValue"
-    )
+        id_vars="GeneID", var_name="SampleID", value_name="NormalizedValue").dropna(
+            subset=["NormalizedValue"])
 
     expressions = []
     for _, row in normalized_df.iterrows():


### PR DESCRIPTION
Normalization using the TPM method was failing due to NaNs. The fix involves removing rows with missing values assuring subsequent data processing with complete data