### PR TITLE
refact: remove bento base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,30 @@
-FROM ghcr.io/bento-platform/bento_base_image:python-debian-2024.07.09
+ARG PYTHON_VERSION=3.12
+ARG DEBIAN_VERSION=slim-bookworm
 
-RUN pip install --no-cache-dir "uvicorn[standard]==0.30.1"
+FROM python:${PYTHON_VERSION}-${DEBIAN_VERSION}
 
+LABEL Maintainer="Bento Project"
+
+RUN apt-get update -y; \
+    apt-get upgrade -y; \
+    apt-get install -y \
+            bash \
+            build-essential \
+            curl \
+            git \
+            gosu \
+            jq \
+            libpq-dev \
+            perl \
+            procps \
+            vim; \
+    rm -rf /var/lib/apt/lists/*;
+
+RUN pip install --no-cache-dir -U pip; \
+    pip install --no-cache-dir poetry==1.8.5; \
+    pip install --no-cache-dir 'uvicorn[standard]>=0.34.0,<0.35'
+
+RUN mkdir /tds /run/secrets
 WORKDIR /tds
 
 COPY pyproject.toml .
@@ -11,7 +34,7 @@ RUN poetry config virtualenvs.create false && \
     poetry --no-cache install --without dev --no-root
 
 COPY transcriptomics_data_service transcriptomics_data_service
-COPY entrypoint.bash .
+COPY gosu_entrypoint.bash .
 COPY run.bash .
 COPY LICENSE .
 COPY README.md .
@@ -19,5 +42,7 @@ COPY README.md .
 # Install the module itself, locally (similar to `pip install -e .`)
 RUN poetry install --without dev
 
-ENTRYPOINT [ "bash", "./entrypoint.bash" ]
+RUN chmod +x ./*.bash
+
+ENTRYPOINT [ "bash", "./gosu_entrypoint.bash" ]
 CMD [ "bash", "./run.bash" ]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,46 @@ For testing purposes, this repository includes an RCM and gene lenghts file:
 - [rcm_file.csv](tests/data/rcm_file.csv)
 - [gene_lengths.csv](tests/data/gene_lengths.csv)
 
+### Environment variables
+
+The following environment variables should be set when running a TDS container:
+
+| Name               | Description                                          | Default    |
+| ------------------ | ---------------------------------------------------- | ---------- |
+| `TDS_USER_NAME`    | Non-root container user name running the TDS process | `Null`     |
+| `TDS_UID`          | UID of TDS_USER_NAME                                 | `1000`     |
+| `DB_HOST`          | IP or hostname of the database                       | `tds-db`   |
+| `DB_PORT`          | Database port                                        | `5432`     |
+| `DB_USER`          | Database username                                    | `tds_user` |
+| `DB_NAME`          | Database name                                        | `tds`      |
+| `DB_PASSWORD`      | DB_USER's Database password                          | `Null`     |
+| `DB_PASSWORD_FILE` | Docker secret file for DB_USER's Database password   | `Null`     |
+| `CORS_ORIGINS`     | List of allowed CORS origins                         | `Null`     |
+
+**Note:** Only use `DB_PASSWORD` or `DB_PASSWORK_FILE`, not both, since they serve the same purpose in a different fashion.
+
+## Using Docker Secrets for the PostgreSQL credential
+
+The TDS [`Config`](./transcriptomics_data_service/config.py) object has its values populated from environment variables and secrets at startup.
+
+The `Config.db_password` value is populated by either:
+- `DB_PASSWORD=<a secure password>` if using an environment variable
+  - As seen in [docker-compose.dev.yaml](./docker-compose.dev.yaml)
+- `DB_PASSWORD_FILE=/run/secrets/db_password` if using a Docker secret (recommended)
+  - As seen in [docker-compose.secrets.dev.yaml](./docker-compose.secrets.dev.yaml)
+
+Using a Docker secret is recommended for security, as environment variables are more prone to be leaked.
+
+`DB_PASSWORD` should only be considered for local development, or if the database is secured and isolated from public access in a private network.
+
+## Authorization plugin
+
+The Transcriptomics Data Service is meant to be a reusable microservice that can be integrated in existing 
+stacks. Since authorization schemes vary across projects, TDS allows adopters to code their own authorization plugin, 
+enabling adopters to leverage their existing access control code, tools and policies.
+
+See the [authorization docs](./docs/authz.md) for more information on how to create and use the authz plugin with TDS.
+
 ## Starting a standalone TDS
 
 Start the TDS server with a local PostgreSQL database for testing by running the following command.
@@ -63,28 +103,6 @@ docker compose -f ./docker-compose.dev.yaml down
 ```
 
 You can then attach VS Code to the `tds` container, and use the preconfigured `Python Debugger (TDS)` for interactive debugging.
-
-## Using Docker Secrets for the PostgreSQL credential
-
-The TDS [`Config`](./transcriptomics_data_service/config.py) object has its values populated from environment variables and secrets at startup.
-
-The `Config.db_password` value is populated by either:
-- `DB_PASSWORD=<a secure password>` if using an environment variable
-  - As seen in [docker-compose.dev.yaml](./docker-compose.dev.yaml)
-- `DB_PASSWORD_FILE=/run/secrets/db_password` if using a Docker secret (recommended)
-  - As seen in [docker-compose.secrets.dev.yaml](./docker-compose.secrets.dev.yaml)
-
-Using a Docker secret is recommended for security, as environment variables are more prone to be leaked.
-
-`DB_PASSWORD` should only be considered for local development, or if the database is secured and isolated from public access in a private network.
-
-## Authorization plugin
-
-The Transcriptomics Data Service is meant to be a reusable microservice that can be integrated in existing 
-stacks. Since authorization schemes vary across projects, TDS allows adopters to code their own authorization plugin, 
-enabling adopters to leverage their existing access control code, tools and policies.
-
-See the [authorization docs](./docs/authz.md) for more information on how to create and use the authz plugin with TDS.
 
 ## Endpoints
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,8 @@ LABEL devcontainer.metadata='[{ \
       "extensions": ["ms-python.python", "eamodio.gitlens", "ms-python.black-formatter"], \
       "settings": {"workspaceFolder": "/tds"} \
     } \
-  } \
+  }, \
+  "remoteUser": "tds" \
 }]'
 
 RUN apt-get update -y; \

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -9,7 +9,8 @@ services:
     depends_on:
       - tds-db
     environment:
-      - BENTO_UID=${UID}
+      - TDS_USER_NAME=tds-usr
+      - TDS_UID=${UID}
       - DB_HOST=tds-db
       - DB_PORT=5432
       - DB_USER=tds_user

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - tds-db
     environment:
-      - TDS_USER_NAME=tds-usr
+      - TDS_USER_NAME=tds   # set to match the expected 'devcontainer' remoteUser of the dev.Dockerfile
       - TDS_UID=${UID}
       - DB_HOST=tds-db
       - DB_PORT=5432

--- a/docker-compose.secrets.dev.yaml
+++ b/docker-compose.secrets.dev.yaml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - tds-db
     environment:
-      - TDS_USER_NAME=tds-usr
+      - TDS_USER_NAME=tds
       - TDS_UID=${UID}
       - DB_HOST=tds-db
       - DB_PORT=5432

--- a/docker-compose.secrets.dev.yaml
+++ b/docker-compose.secrets.dev.yaml
@@ -9,7 +9,8 @@ services:
     depends_on:
       - tds-db
     environment:
-      - BENTO_UID=${UID}
+      - TDS_USER_NAME=tds-usr
+      - TDS_UID=${UID}
       - DB_HOST=tds-db
       - DB_PORT=5432
       - DB_USER=tds_user

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -9,8 +9,8 @@ services:
     depends_on:
       - tds-db
     environment:
-      - BENTO_UID=${UID}
-      # - DATABASE_URI=postgres://tds_user:tds_password@tds-db:5432/tds_db
+      - TDS_USER_NAME=tds-user
+      - TDS_UID=${UID}
       - DB_HOST=tds-db
       - DB_PORT=5432
       - DB_USER=tds_user

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - tds-db
     environment:
-      - TDS_USER_NAME=tds-user
+      - TDS_USER_NAME=tds
       - TDS_UID=${UID}
       - DB_HOST=tds-db
       - DB_PORT=5432

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - tds-db
     environment:
-      - TDS_USER_NAME=tds-user
+      - TDS_USER_NAME=tds
       - TDS_UID=${UID}
       - DB_HOST=tds-db
       - DB_PORT=5432

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     depends_on:
       - tds-db
     environment:
+      - TDS_USER_NAME=tds-user
+      - TDS_UID=${UID}
       - DB_HOST=tds-db
       - DB_PORT=5432
       - DB_USER=tds_user

--- a/gosu_entrypoint.bash
+++ b/gosu_entrypoint.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Setup non-root user
+USER_NAME=${TDS_USER_NAME}
+USER_ID=${TDS_UID:-1000}
+GROUP_ID=${TDS_GID:-$USER_ID}
+groupadd -g "${GROUP_ID}" -r ${USER_NAME}
+useradd --shell /bin/bash -u "${USER_ID}" -r -g "${GROUP_ID}" --non-unique -c "TDS container user" -m ${USER_NAME}
+export HOME=/home/${USER_NAME}
+echo "PATH=/home/${USER_NAME}/.local/bin/:\$PATH" >> "/home/${USER_NAME}/.bashrc"
+
+chown -R ${USER_NAME}:${USER_NAME} /tds
+chown -R ${USER_NAME}:${USER_NAME} /run/secrets
+
+# Drop into ${USER_NAME} from root and execute the CMD specified for the image
+exec gosu "${USER_NAME}" "$@"

--- a/run.dev.bash
+++ b/run.dev.bash
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Update dependencies and install module locally
-/poetry_user_install_dev.bash
+poetry export -f requirements.txt --with dev --output requirements.txt
+pip install --no-cache-dir --user -r requirements.txt
+rm requirements.txt
+pip install -e .
 
 # Extra dependencies installation for authz plugin
 if [ -f /tds/lib/requirements.txt ]; then

--- a/test-docker.bash
+++ b/test-docker.bash
@@ -4,9 +4,12 @@ export UID=$(id -u)
 docker compose -f docker-compose.test.yaml down
 docker compose -f docker-compose.test.yaml up  -d --build --wait
 
-docker exec tds /bin/bash -c "
+docker exec --user "${UID}" tds /bin/bash -c "
     cd /tds &&
-    /poetry_user_install_dev.bash &&
+    poetry export -f requirements.txt --with dev --output requirements.txt
+    pip install --no-cache-dir --user -r requirements.txt
+    rm requirements.txt
+    pip install -e .
     pytest -svv --cov=transcriptomics_data_service --cov-branch &&
     coverage html
     "


### PR DESCRIPTION
Removes the Bento base image, while keeping a non-root user whose name, UID and GID can be provided when running the container.
The Dockerfile entrypoint handles the non-root user creation, simply provide these environment variables:
- `TDS_USER` : username that will run the service
- `TDS_UID`: Numeric user ID of `TDS_USER` (defaults to 1000)
- `TDS_GID`: Numeric group ID (defaults to `TDS_UID`)