### PR TITLE
feat: experiment extra properties

### DIFF
--- a/authz_plugins/bento/authz.module.py
+++ b/authz_plugins/bento/authz.module.py
@@ -64,6 +64,9 @@ class BentoAuthzMiddleware(FastApiAuthMiddleware, BaseAuthzMiddleware):
 
     # EXPERIMENT RESULT router paths
 
+    def dep_authz_create_experiment_result(self):
+        return [self._dep_require_permission_injected_resource(P_INGEST_DATA)]
+
     def dep_authz_get_experiment_result(self):
         return [self._dep_require_permission_injected_resource(P_QUERY_DATA)]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ async def db_cleanup(db: Database):
 @pytest_asyncio.fixture
 async def db_with_experiment(db: Database):
     await db.create_experiment_result(TEST_EXPERIMENT_RESULT)
+    return TEST_EXPERIMENT_RESULT
 
 
 @pytest.fixture

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,6 +7,7 @@ TEST_EXPERIMENT_RESULT = ExperimentResult(
     experiment_result_id=TEST_EXPERIMENT_RESULT_ID,
     assembly_id="assembly_test_id",
     assembly_name="assembly_test_name",
+    extra_properties={"project": "project-a", "dataset": "dataset-b"},
 )
 TEST_GENE_EXPRESSION = GeneExpression(
     experiment_result_id=TEST_EXPERIMENT_RESULT_ID,

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -9,6 +9,26 @@ config = get_config()
 logger = get_logger(config)
 
 
+def test_create_experiment(test_client, authz_headers, db_cleanup):
+    response = test_client.post("/experiment", headers=authz_headers, data=TEST_EXPERIMENT_RESULT.model_dump_json())
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_experiment_400(test_client, authz_headers, db_cleanup):
+    response = test_client.post(
+        "/experiment",
+        headers=authz_headers,
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_create_experiment_403(test_client, authz_headers_bad, db_cleanup):
+    response = test_client.post(
+        "/experiment", headers=authz_headers_bad, data=TEST_EXPERIMENT_RESULT.model_dump_json()
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
 def test_get_experiment(test_client, authz_headers, db_with_experiment, db_cleanup):
     # TEST_EXPERIMENT_RESULT_ID
     response = test_client.get(

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -10,7 +10,11 @@ logger = get_logger(config)
 
 
 def test_create_experiment(test_client, authz_headers, db_cleanup):
-    response = test_client.post("/experiment", headers=authz_headers, data=TEST_EXPERIMENT_RESULT.model_dump_json())
+    response = test_client.post(
+        "/experiment",
+        headers=authz_headers,
+        data=TEST_EXPERIMENT_RESULT.model_dump_json(),
+    )
     assert response.status_code == status.HTTP_200_OK
 
 
@@ -24,7 +28,9 @@ def test_create_experiment_400(test_client, authz_headers, db_cleanup):
 
 def test_create_experiment_403(test_client, authz_headers_bad, db_cleanup):
     response = test_client.post(
-        "/experiment", headers=authz_headers_bad, data=TEST_EXPERIMENT_RESULT.model_dump_json()
+        "/experiment",
+        headers=authz_headers_bad,
+        data=TEST_EXPERIMENT_RESULT.model_dump_json(),
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,4 +1,5 @@
 from fastapi import status
+import pytest
 
 from tests.test_db import TEST_EXPERIMENT_RESULT
 from transcriptomics_data_service.config import get_config
@@ -8,12 +9,19 @@ from transcriptomics_data_service.models import ExperimentResult
 config = get_config()
 logger = get_logger(config)
 
+TEST_EXPERIMENT_RESULT_NO_EXTRA = ExperimentResult(
+    experiment_result_id="12345",
+    assembly_id="assembly_test_id",
+    assembly_name="assembly_test_name",
+)
 
-def test_create_experiment(test_client, authz_headers, db_cleanup):
+
+@pytest.mark.parametrize("exp", [TEST_EXPERIMENT_RESULT, TEST_EXPERIMENT_RESULT_NO_EXTRA])
+def test_create_experiment(exp, test_client, authz_headers, db_cleanup):
     response = test_client.post(
         "/experiment",
         headers=authz_headers,
-        data=TEST_EXPERIMENT_RESULT.model_dump_json(),
+        data=exp.model_dump_json(),
     )
     assert response.status_code == status.HTTP_200_OK
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -29,7 +29,6 @@ def _ingest_rcm_file(
             files=[("rcm_file", file)],
             headers=headers,
         )
-    logger.debug(res.json())
     return res
 
 
@@ -64,6 +63,16 @@ def test_ingest_authorized_duplicate(test_client, authz_headers, db_cleanup, db_
         headers=authz_headers,
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_ingest_404(test_client, authz_headers, db_cleanup):
+    # db_with_experiment fixture not included, targeted experiment doesn't exist
+    response = _ingest_rcm_file(
+        test_client,
+        file_path=RCM_FILE_PATH,
+        headers=authz_headers,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_ingest_parser_error(test_client, authz_headers, db_cleanup, db_with_experiment):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from tests.conftest import TEST_EXPERIMENT_RESULT
 from transcriptomics_data_service.config import get_config
 from httpx._types import HeaderTypes
 
@@ -15,24 +16,16 @@ logger = get_logger(config)
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "data")
 RCM_FILE_PATH = f"{TEST_FILES_DIR}/rcm_file.csv"
-INGEST_ARGS = dict(
-    exp_id="exp-12345",
-    assembly_name="GRCh38",
-    assembly_id="GCF_000001405.26",
-)
 
 
 def _ingest_rcm_file(
     client: TestClient,
-    exp_id: str,
-    assembly_name: str,
-    assembly_id: str,
     file_path: Path,
     headers: HeaderTypes | None = None,
 ):
     with open(file_path, "rb") as file:
         res = client.post(
-            url=f"/ingest/{exp_id}/assembly-name/{assembly_name}/assembly-id/{assembly_id}",
+            url=f"/experiment/{TEST_EXPERIMENT_RESULT.experiment_result_id}/ingest",
             files=[("rcm_file", file)],
             headers=headers,
         )
@@ -40,88 +33,81 @@ def _ingest_rcm_file(
     return res
 
 
-def test_ingest_missing_api_key(test_client: TestClient, db_cleanup):
+def test_ingest_missing_api_key(test_client: TestClient, db_cleanup, db_with_experiment):
     # No API key
-    response = _ingest_rcm_file(test_client, file_path=RCM_FILE_PATH, **INGEST_ARGS)
+    response = _ingest_rcm_file(test_client, file_path=RCM_FILE_PATH)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_ingest_unauthorized(test_client, authz_headers_bad, db_cleanup):
+def test_ingest_unauthorized(test_client, authz_headers_bad, db_cleanup, db_with_experiment):
     response = _ingest_rcm_file(
         test_client,
         file_path=RCM_FILE_PATH,
         headers=authz_headers_bad,
-        **INGEST_ARGS,
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_ingest_authorized(test_client, authz_headers, db_cleanup):
+def test_ingest_authorized(test_client, authz_headers, db_cleanup, db_with_experiment):
     response = _ingest_rcm_file(
         test_client,
         file_path=RCM_FILE_PATH,
         headers=authz_headers,
-        **INGEST_ARGS,
     )
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_ingest_authorized_duplicate(test_client, authz_headers, db_cleanup):
+def test_ingest_authorized_duplicate(test_client, authz_headers, db_cleanup, db_with_experiment):
     response = _ingest_rcm_file(
         test_client,
         file_path=f"{TEST_FILES_DIR}/rcm_file_duplicates.csv",
         headers=authz_headers,
-        **INGEST_ARGS,
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_ingest_parser_error(test_client, authz_headers, db_cleanup):
+def test_ingest_parser_error(test_client, authz_headers, db_cleanup, db_with_experiment):
     response = _ingest_rcm_file(
         test_client,
         file_path=f"{TEST_FILES_DIR}/rcm_file_bad_values.csv",
         headers=authz_headers,
-        **INGEST_ARGS,
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_ingest_invalid_csv(test_client, authz_headers, db_cleanup):
+def test_ingest_invalid_csv(test_client, authz_headers, db_cleanup, db_with_experiment):
     response = _ingest_rcm_file(
         test_client,
         file_path=f"{TEST_FILES_DIR}/rcm_file_bad_column.csv",
         headers=authz_headers,
-        **INGEST_ARGS,
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_normalize_400(test_client: TestClient, db_cleanup):
+def test_normalize_400(test_client: TestClient, db_cleanup, db_with_experiment):
     exp_id_missing = "bad-id"
     method = NormalizationMethodEnum.tpm.value
     response = test_client.post(f"/normalize/{exp_id_missing}/{method}")
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_normalize_403(test_client: TestClient, authz_headers_bad, db_cleanup):
+def test_normalize_403(test_client: TestClient, authz_headers_bad, db_cleanup, db_with_experiment):
     exp_id_missing = "bad-id"
     method = NormalizationMethodEnum.tpm.value
     response = test_client.post(f"/normalize/{exp_id_missing}/{method}", headers=authz_headers_bad)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_normalize_tpm(test_client: TestClient, authz_headers, db_cleanup):
+def test_normalize_tpm(test_client: TestClient, authz_headers, db_cleanup, db_with_experiment):
     response = _ingest_rcm_file(
         test_client,
         file_path=RCM_FILE_PATH,
         headers=authz_headers,
-        **INGEST_ARGS,
     )
-    exp_id = INGEST_ARGS["exp_id"]
     with open(f"{TEST_FILES_DIR}/gene_lengths.csv", "rb") as file:
         for method in NormalizationMethodEnum:
             response = test_client.post(
-                url=f"/normalize/{exp_id}/{method.value}",
+                url=f"/normalize/{TEST_EXPERIMENT_RESULT.experiment_result_id}/{method.value}",
                 files=[("gene_lengths_file", file)],
                 headers=authz_headers,
             )

--- a/transcriptomics_data_service/authz/middleware_base.py
+++ b/transcriptomics_data_service/authz/middleware_base.py
@@ -94,6 +94,10 @@ class BaseAuthzMiddleware:
         return None
 
     ###### EXPERIMENT RESULTS router paths
+
+    def dep_authz_create_experiment_result(self) -> None | Sequence[Depends]:
+        return None
+
     def dep_authz_delete_experiment_result(self) -> None | Sequence[Depends]:
         return None
 

--- a/transcriptomics_data_service/models.py
+++ b/transcriptomics_data_service/models.py
@@ -57,6 +57,7 @@ class ExperimentResult(BaseModel):
     experiment_result_id: str = Field(..., min_length=1, max_length=255)
     assembly_id: str | None = Field(None, max_length=255)
     assembly_name: str | None = Field(None, max_length=255)
+    extra_properties: dict | None = Field(None)
 
 
 class SamplesResponse(PaginatedResponse):

--- a/transcriptomics_data_service/routers/experiment_results.py
+++ b/transcriptomics_data_service/routers/experiment_results.py
@@ -4,6 +4,7 @@ from transcriptomics_data_service.authz.plugin import authz_plugin
 from transcriptomics_data_service.db import DatabaseDependency
 from transcriptomics_data_service.logger import LoggerDependency
 from transcriptomics_data_service.models import (
+    ExperimentResult,
     PaginatedRequest,
     SamplesResponse,
     FeaturesResponse,
@@ -76,6 +77,16 @@ async def get_experiment_features_handler(
         total_pages=total_pages,
         features=features,
     )
+
+
+@experiment_router.post(
+    "",
+    status_code=status.HTTP_200_OK,
+    dependencies=authz_plugin.dep_authz_create_experiment_result(),
+)
+async def create_experiment(db: DatabaseDependency, logger: LoggerDependency, exp: ExperimentResult):
+    await db.create_experiment_result(exp)
+    logger.info(f"Created experiment row with ID: {exp.experiment_result_id}")
 
 
 @experiment_router.get("", dependencies=authz_plugin.dep_authz_list_experiment_results())

--- a/transcriptomics_data_service/routers/ingest.py
+++ b/transcriptomics_data_service/routers/ingest.py
@@ -17,8 +17,7 @@ GENE_ID_KEY = "GeneID"
 
 
 @ingest_router.post(
-    # "/ingest/{experiment_result_id}",
-    "/experiment/{experiment_result_id}/ingest/",
+    "/experiment/{experiment_result_id}/ingest",
     status_code=status.HTTP_200_OK,
     # Injects the plugin authz middleware dep_authorize_ingest function
     dependencies=authz_plugin.dep_authz_ingest(),

--- a/transcriptomics_data_service/routers/ingest.py
+++ b/transcriptomics_data_service/routers/ingest.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from transcriptomics_data_service.db import DatabaseDependency
 from transcriptomics_data_service.logger import LoggerDependency
-from transcriptomics_data_service.models import ExperimentResult, GeneExpression
+from transcriptomics_data_service.models import GeneExpression
 from transcriptomics_data_service.authz.plugin import authz_plugin
 
 __all__ = ["ingest_router"]
@@ -17,32 +17,32 @@ GENE_ID_KEY = "GeneID"
 
 
 @ingest_router.post(
-    "/ingest/{experiment_result_id}/assembly-name/{assembly_name}/assembly-id/{assembly_id}",
+    # "/ingest/{experiment_result_id}",
+    "/experiment/{experiment_result_id}/ingest/",
     status_code=status.HTTP_200_OK,
     # Injects the plugin authz middleware dep_authorize_ingest function
     dependencies=authz_plugin.dep_authz_ingest(),
+    description="Ingest a raw counts matrix RCM into an existing experiment",
 )
 async def ingest(
     db: DatabaseDependency,
     logger: LoggerDependency,
     experiment_result_id: str,
-    assembly_name: str,
-    assembly_id: str,
     rcm_file: UploadFile = File(...),
 ):
     # Reading and converting uploaded RCM file to DataFrame
     file_bytes = rcm_file.file.read()
     rcm_df = _load_csv(file_bytes, logger)
 
+    experiment_result = await db.read_experiment_result(experiment_result_id)
+    if experiment_result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No experiment result found for provided ID",
+        )
+
     # Handling ingestion as a transactional operation
     async with db.transaction_connection() as transaction_con:
-        experiment_result = ExperimentResult(
-            experiment_result_id=experiment_result_id,
-            assembly_name=assembly_name,
-            assembly_id=assembly_id,
-        )
-        await db.create_experiment_result(experiment_result, transaction_con)
-
         gene_expressions: list[GeneExpression] = [
             GeneExpression(
                 gene_code=gene_code,

--- a/transcriptomics_data_service/sql/schema.sql
+++ b/transcriptomics_data_service/sql/schema.sql
@@ -1,7 +1,8 @@
 CREATE TABLE IF NOT EXISTS experiment_results (
     experiment_result_id VARCHAR(255) NOT NULL PRIMARY KEY,
     assembly_id VARCHAR(255),
-    assembly_name VARCHAR(255)
+    assembly_name VARCHAR(255),
+    extra_properties JSON
 );
 
 CREATE TABLE IF NOT EXISTS gene_expressions (


### PR DESCRIPTION
This PR includes the following changes:

- `ExperimentResult` model now has an `extra_properties` field to store arbitrary JSON data
   - `experiment_results.extra_properties` in the SQL schema
   - Allows to store useful information for authorization checks, rather than baking information in the IDs
-  New endpoint for experiment creation: `POST /experiment`
-  Replaced `POST /ingest/{exp_id}` endpoint with `POST /experiment/{exp_id}/ingest`
   - Now requires a pre-existing expriment to perform ingestion 
